### PR TITLE
Fix integer overflow warning

### DIFF
--- a/lib/Battery/BatteryProtection.h
+++ b/lib/Battery/BatteryProtection.h
@@ -6,10 +6,10 @@
 #include <ExponentialSmoothing.h>
 
 const float  LOW_POWER_VOLTAGE = 10.8;
-const unsigned long LOW_POWER_TIME_MS = (1 * 60 * 1000);
+const unsigned long LOW_POWER_TIME_MS = (1L * 60 * 1000);
 
 const float BATTERY_PROTECTION_VOLTAGE = 10.5;
-const unsigned long BATTERY_PROTECTION_MS = (1 * 60 * 1000);
+const unsigned long BATTERY_PROTECTION_MS = (1L * 60 * 1000);
 
 class BatteryProtection {
 


### PR DESCRIPTION
As the evaluation of the righthand side of the expression is done before
assignment to the left-side unsigned long variable, the multiplication of the
three integer values (result 60000) exceeds the upper bound for signed integer
values.

Suffixing the first right-hand value with `L` tells the compiler that the value
is of type `long`, which causes the expression to be evaluated as the
multiplication of `long` values instead of `int` values.